### PR TITLE
Implement byte-format content matching

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,15 @@ futures = "0.3"
 reqwest = "0.10"
 dns-lookup = "0.9"
 tokio = {version = "0.2", features = ["time"] }
+## Static build
+# Add openssl-sys as a direct dependency so it can be cross compiled to
+# x86_64-unknown-linux-musl using the "vendored" feature below
+openssl-sys = "*"
+
+[features]
+# Force openssl-sys to staticly link in the openssl library.
+# Necessary when cross compiling to x86_64-unknown-linux-musl.
+vendored = ["openssl-sys/vendored"]
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["full"] }

--- a/examples/mass_content_scan.rs
+++ b/examples/mass_content_scan.rs
@@ -1,0 +1,45 @@
+extern crate webscan;
+use webscan::{UriScanner, ScanStatus, RequestMethod};
+use tokio;
+use std::fs::{read_to_string, read};
+use std::time::Duration;
+use futures::executor;
+
+#[tokio::main]
+async fn main(){
+    match read_to_string("targets.txt") {
+        Ok(tgt) => {
+            let urls: Vec<&str> = tgt.trim().split("\n").collect();
+            urls.iter().for_each(|u| {
+                let mut uri_scanner = match UriScanner::new(){
+                    Ok(scanner) => (scanner),
+                    Err(e) => panic!("Error creating scanner: {}", e),
+                };
+                uri_scanner.set_base_uri(u.to_string());
+                match read("content.txt") {
+                    Ok(ct) => {
+                        let sep = b'\n';
+                        ct.split(|b| b == &sep )
+                            .for_each(|c| uri_scanner.add_content(c.to_vec()));
+                    },
+                    Err(e) => {panic!("Could not open or find content.txt file: {}", e);}
+                }
+                uri_scanner.set_request_method(RequestMethod::Get);
+                uri_scanner.set_timeout(Duration::from_millis(20000));
+                uri_scanner.set_accept_invalid_certs(true);
+                executor::block_on(uri_scanner.run_scan());
+                let result = uri_scanner.get_result();
+                match result.scan_status {
+                    ScanStatus::Done => {
+                        for (uri, status) in result.responses {
+                            if status.starts_with("2") { println!("{}", uri) }
+                        }
+                    },
+                    ScanStatus::Timeout => {println!("Timed out")},
+                    _ => {println!("Error")},
+                };
+            });
+        },
+        Err(e) => {panic!("Could not open or find targets.txt file: {}", e);}
+    };
+}

--- a/examples/mass_content_scan.rs
+++ b/examples/mass_content_scan.rs
@@ -3,42 +3,53 @@ use webscan::{UriScanner, ScanStatus, RequestMethod};
 use tokio;
 use std::fs::{read_to_string, read};
 use std::time::Duration;
-use futures::executor;
 
 #[tokio::main]
 async fn main(){
+    // Set up base scanner template struct to clone
+    let mut base_scanner = match UriScanner::new(){
+        Ok(scanner) => scanner,
+        Err(e) => panic!("Error creating scanner: {}", e),
+    };
+    base_scanner.set_request_method(RequestMethod::Get);
+    base_scanner.set_timeout(Duration::from_millis(20000));
+    base_scanner.set_accept_invalid_certs(true);
+    // Get byte vectors of content
+    match read("content.txt") {
+        Ok(ct) => {
+            let sep = b'\n';
+            ct.split(|b| b == &sep )
+                .for_each(|c| base_scanner.add_content(c.to_vec()));
+        },
+        Err(e) => {panic!("Could not open or find content.txt file: {}", e);}
+    };
+    // Get strings of target URLs    
     match read_to_string("targets.txt") {
         Ok(tgt) => {
             let urls: Vec<&str> = tgt.trim().split("\n").collect();
-            urls.iter().for_each(|u| {
-                let mut uri_scanner = match UriScanner::new(){
-                    Ok(scanner) => (scanner),
-                    Err(e) => panic!("Error creating scanner: {}", e),
-                };
-                uri_scanner.set_base_uri(u.to_string());
-                match read("content.txt") {
-                    Ok(ct) => {
-                        let sep = b'\n';
-                        ct.split(|b| b == &sep )
-                            .for_each(|c| uri_scanner.add_content(c.to_vec()));
-                    },
-                    Err(e) => {panic!("Could not open or find content.txt file: {}", e);}
-                }
-                uri_scanner.set_request_method(RequestMethod::Get);
-                uri_scanner.set_timeout(Duration::from_millis(20000));
-                uri_scanner.set_accept_invalid_certs(true);
-                executor::block_on(uri_scanner.run_scan());
-                let result = uri_scanner.get_result();
-                match result.scan_status {
-                    ScanStatus::Done => {
-                        for (uri, status) in result.responses {
-                            if status.starts_with("2") { println!("{}", uri) }
-                        }
-                    },
-                    ScanStatus::Timeout => {println!("Timed out")},
-                    _ => {println!("Error")},
-                };
-            });
+            // Build set of scanners for all targets
+            let mut scanners: Vec<UriScanner> = urls.iter().map(|u| {
+                let mut scanner = base_scanner.clone();
+                scanner.set_base_uri(u.to_string());
+                scanner
+            }).collect();
+            // Run scanners in parallel
+            while let Some(mut scanner) = scanners.pop() {
+                tokio::spawn(async move {
+                    scanner.run_scan().await;
+                    let result = scanner.get_result();
+                    match result.scan_status {
+                        ScanStatus::Done => {
+                            for (uri, status) in result.responses {
+                                // Content matches are "given" a 200 response string
+                                if status.starts_with("2") { println!("{}", uri) }
+                            }
+                        },
+                        ScanStatus::Timeout => {println!("Timed out")},
+                        _ => {println!("Error")},
+                    };
+                });
+            };
         },
         Err(e) => {panic!("Could not open or find targets.txt file: {}", e);}
     };

--- a/examples/uri_scan.rs
+++ b/examples/uri_scan.rs
@@ -1,7 +1,7 @@
 extern crate webscan;
 use webscan::{UriScanner, ScanStatus, RequestMethod};
 use tokio;
-use std::fs::read_to_string;
+use std::fs::{read_to_string, read};
 use std::time::Duration;
 
 #[tokio::main]
@@ -10,18 +10,26 @@ async fn main(){
         Ok(scanner) => (scanner),
         Err(e) => panic!("Error creating scanner: {}", e),
     };
-    let base_uri = String::from("http://192.168.1.8/xvwa/");
+    let base_uri = String::from("http://localhost:8000/");
     uri_scanner.set_base_uri(base_uri);
-    let data = read_to_string("common.txt");
+    let data = read_to_string("uris.txt");
     let text = match data {
         Ok(content) => content,
-        Err(e) => {panic!("Could not open or find file: {}", e);}
+        Err(e) => {panic!("Could not open or find uris.txt file: {}", e);}
     };
     let word_list: Vec<&str> = text.trim().split("\n").collect();
     for word in word_list {
         uri_scanner.add_word(word.to_string());
     }
-    uri_scanner.set_request_method(RequestMethod::Head);
+    match read("content.txt") {
+        Ok(ct) => {
+            let sep = b'\n';
+            ct.split(|b| b == &sep )
+                .for_each(|c| uri_scanner.add_content(c.to_vec()));
+        },
+        Err(e) => {panic!("Could not open or find content.txt file: {}", e);}
+    }
+    uri_scanner.set_request_method(RequestMethod::Get);
     uri_scanner.set_timeout(Duration::from_millis(20000));
     uri_scanner.set_accept_invalid_certs(false);
     uri_scanner.run_scan().await;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,8 @@ pub type NewDomainScannerResult = Result<DomainScanner, String>;
 
 /// Structure for uri scan  
 /// 
-/// Should be constructed using UriScanner::new 
+/// Should be constructed using UriScanner::new
+#[derive(Clone)]
 pub struct UriScanner {
     /// Base URI of scan target.  
     base_uri: String,
@@ -38,7 +39,8 @@ pub struct UriScanner {
 
 /// Structure for domain scan  
 /// 
-/// Should be constructed using DomainScanner::new 
+/// Should be constructed using DomainScanner::new
+#[derive(Clone)]
 pub struct DomainScanner {
     /// Base Domain Name of scan target.  
     base_domain: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@ pub struct UriScanner {
     accept_invalid_certs: bool,
     /// Result of uri scan.  
     scan_result: UriScanResult,
+    /// List of content buffers to find in returned pages
+    content_list: Vec<Vec<u8>>,
 }
 
 /// Structure for domain scan  
@@ -89,6 +91,7 @@ impl UriScanner{
             timeout: Duration::from_millis(30000),
             accept_invalid_certs: false,
             scan_result: ini_scan_result,
+            content_list: vec![],
         };
         Ok(uri_scanner)
     }
@@ -98,7 +101,7 @@ impl UriScanner{
     }
     /// Add word(file name or dir name) to word-list
     pub fn add_word(&mut self, word: String) {
-        self.word_list.push(word);
+        if word.len() != 0 { self.word_list.push(word) }
     }
     /// Set request method
     pub fn set_request_method(&mut self, method: RequestMethod) {
@@ -112,12 +115,16 @@ impl UriScanner{
     pub fn set_accept_invalid_certs(&mut self, accept: bool) {
         self.accept_invalid_certs = accept;
     }
+    /// Add content vector to search for in response bytes
+    pub fn add_content(&mut self, content: Vec<u8>) {
+        if content.len() != 0 { self.content_list.push(content) }
+    }
     /// Run scan with current settings. 
     /// 
     /// Results are stored in UriScanner::scan_result
     pub async fn run_scan(&mut self){
         let start_time = Instant::now();
-        let res = timeout(self.timeout, uri::scan_uri(&self.base_uri, &self.word_list, &self.request_method, self.accept_invalid_certs)).await;
+        let res = timeout(self.timeout, uri::scan_uri(&self.base_uri, &self.word_list, &self.request_method, self.accept_invalid_certs, &self.content_list)).await;
         match res {
             Ok(responses) => {
                 self.scan_result.responses = responses;

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 /// HTTP request method for scanning
+#[derive(Clone)]
 pub enum RequestMethod {
     Get,
     Post,

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -31,6 +31,9 @@ pub async fn scan_uri(base_uri: &String, word_list: &Vec<String>, req_method: &R
     for w in word_list{
         target_uris.push(format!("{}{}", base_uri, w));
     }
+    if target_uris.len() == 0 {
+        target_uris.push(base_uri.to_owned());
+    }
     let results = stream::iter(target_uris).map(|uri| {
         let client = &client;
         async move {


### PR DESCRIPTION
Sometimes users need to find the presence of content in a response
instead of just knowing if a URI exists. Sometimes, the content is
in a language using a character set other than UTF-8. Sometimes,
users need to do this very quickly and at scale. Now is one of
those times.

Implement a `Vec<Vec<u8>>` in the UriScanner struct to hold a set
of desired matches from content acquired by requests. Implement a
check for the presence of elements in that outer vector, which if
successful will attempt to find each element in the outer vector in
the bytes of the response (ignoring the response code produced).

Fix a logic flaw that allowed empty words to be added to the URI
list (`Vec<String>`).

Testing:
  Minimal through update to the uri_scanner example - doesn't blow
up yet, finds results, works as previously with no content matches
supplied.